### PR TITLE
fixed discord id validation

### DIFF
--- a/database_adapter/src/server.py
+++ b/database_adapter/src/server.py
@@ -60,7 +60,7 @@ def get_discord_id_from_shortcode(
 
 @discord_id_router.get("/shortcode")
 def get_shortcode_from_discord_id(
-    id: str = Query(min_length=17, max_length=19, pattern=DISCORD_ID_REGEX)
+    id: str = Query(min_length=17, max_length=19)
 ) -> dict:
     """
     Get the shortcode from the Discord ID


### PR DESCRIPTION
its expected just the number not the <@ > parts (and the validation contridicts itself